### PR TITLE
Handle yii\web\UnauthorizedHttpException

### DIFF
--- a/JsonRpcRequest.php
+++ b/JsonRpcRequest.php
@@ -2,6 +2,7 @@
 
 namespace georgique\yii2\jsonrpc;
 
+use georgique\yii2\jsonrpc\exceptions\InvalidRequestException;
 use georgique\yii2\jsonrpc\exceptions\JsonRpcException;
 use georgique\yii2\jsonrpc\exceptions\InternalErrorException;
 use georgique\yii2\jsonrpc\exceptions\InvalidParamsException;
@@ -15,6 +16,7 @@ use yii\web\Application;
 use yii\web\BadRequestHttpException;
 use yii\web\NotFoundHttpException;
 use yii\web\Response;
+use yii\web\UnauthorizedHttpException;
 
 /**
  * Class JsonRpcRequest
@@ -186,6 +188,8 @@ class JsonRpcRequest extends Model
 
                 $result = $app->runAction($routeParsed, $params);
             }
+        } catch (UnauthorizedHttpException $e) {
+          throw new InvalidRequestException("Unauthorized",  [], $e);
         } catch (JsonRpcException $e) {
             throw $e;
         } catch (BadRequestHttpException $e) {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Yii2 extension for JSON-RPC server implementation. Works not as Remote Procedure Call, but Remote Action Call, therefor leaves all Yii2 power for your service.
 
-[![Build Status](https://travis-ci.org/georgique/yii2-jsonrpc.svg?branch=master)](https://travis-ci.org/xzag/yii2-jsonrpc)
+[![Build Status](https://travis-ci.org/georgique/yii2-jsonrpc.svg?branch=master)](https://travis-ci.org/georgique/yii2-jsonrpc)
 
 ## Features
 * Uses full Yii2 power, because method string is translated into a route. 


### PR DESCRIPTION
This adds support for `yii\filters\auth\CompositeAuth`/ `yii\filters\auth\HttpBearerAuth`behaviors which let you authenticate a json-rpc request via the http header Authorization: Bearer <token>`. Failed authentication now results in a proper json-rpc error ("Invalid request", since the json-rpc standard doesn't provide any custom error for authentication failure).